### PR TITLE
support for secp and eth_secp keys

### DIFF
--- a/packages/realiojs/package.json
+++ b/packages/realiojs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@realiotech/realiojs",
   "description": "JS and TS libs for Realio Network",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -22,7 +22,7 @@
     "@realiotech/address-generator": "^1.0.1",
     "@realiotech/proto": "^2.2.0",
     "@realiotech/provider": "^2.0.1",
-    "@realiotech/transactions": "^2.2.0",
+    "@realiotech/transactions": "^2.3.0",
     "@types/node": "^17.0.21",
     "shx": "^0.3.4"
   },

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@realiotech/transactions",
   "description": "Transactions generator for RealioNetwork",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Extends the sdk to support the pub keys from both the cosmos standard account and the ethermint protoype.