### PR TITLE
Separate tx body creation

### DIFF
--- a/packages/proto/package.json
+++ b/packages/proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@realiotech/proto",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "Protobuf files for RealioNetwork",
   "license": "MIT",
   "eslintIgnore": [

--- a/packages/proto/src/transaction/transaction.ts
+++ b/packages/proto/src/transaction/transaction.ts
@@ -124,7 +124,7 @@ export function createTransactionWithMultipleMessages(
   sequence: number,
   accountNumber: number,
   chainId: string,
-  algo: string = ETH_SECP256K1
+  algo: string = ETH_SECP256K1,
 ) {
   const body = createBodyWithMultipleMessages(messages, memo)
   const feeMessage = createFee(fee, denom, gasLimit)
@@ -135,7 +135,7 @@ export function createTransactionWithMultipleMessages(
     new Uint8Array(pubKeyDecoded),
     sequence,
     LEGACY_AMINO,
-    algo
+    algo,
   )
 
   const authInfoAmino = createAuthInfo(signInfoAmino, feeMessage)
@@ -156,7 +156,7 @@ export function createTransactionWithMultipleMessages(
     new Uint8Array(pubKeyDecoded),
     sequence,
     SIGN_DIRECT,
-    algo
+    algo,
   )
 
   const authInfoDirect = createAuthInfo(signInfoDirect, feeMessage)
@@ -208,6 +208,89 @@ export function createTransaction(
     sequence,
     accountNumber,
     chainId,
-    algo
+    algo,
   )
+}
+
+/**
+ * Returns a transaction object with the body, authInfo and signBytes for both Amino and SignDirect
+ * @param body - The body of the transaction. Must be a valid tx.cosmos.tx.v1beta1.TxBody
+ * @param fee - The fee amount
+ * @param denom - The fee denomination
+ * @param gasLimit - The gas limit
+ * @param pubKey - The public key of the sender
+ * @param sequence - The sequence number of the sender
+ * @param accountNumber - The account number of the sender
+ * @param chainId - The chain ID
+ * @param algo - The algorithm used to sign the transaction. Defaults to ETH_SECP256K1
+ * @returns An object with the legacyAmino and signDirect properties
+ */
+export function createTransactionWithBody(
+  body: any,
+  fee: string,
+  denom: string,
+  gasLimit: number,
+  pubKey: string,
+  sequence: number,
+  accountNumber: number,
+  chainId: string,
+  algo: string = ETH_SECP256K1,
+) {
+  const feeMessage = createFee(fee, denom, gasLimit)
+  const pubKeyDecoded = Buffer.from(pubKey, 'base64')
+
+  // AMINO
+  const signInfoAmino = createSignerInfo(
+    new Uint8Array(pubKeyDecoded),
+    sequence,
+    LEGACY_AMINO,
+    algo,
+  )
+
+  const authInfoAmino = createAuthInfo(signInfoAmino, feeMessage)
+
+  const signDocAmino = createSigDoc(
+    body.serializeBinary(),
+    authInfoAmino.serializeBinary(),
+    chainId,
+    accountNumber,
+  )
+
+  const hashAmino = new Keccak(256)
+  hashAmino.update(Buffer.from(signDocAmino.serializeBinary()))
+  const toSignAmino = hashAmino.digest('binary')
+
+  // SignDirect
+  const signInfoDirect = createSignerInfo(
+    new Uint8Array(pubKeyDecoded),
+    sequence,
+    SIGN_DIRECT,
+    algo,
+  )
+
+  const authInfoDirect = createAuthInfo(signInfoDirect, feeMessage)
+
+  const signDocDirect = createSigDoc(
+    body.serializeBinary(),
+    authInfoDirect.serializeBinary(),
+    chainId,
+    accountNumber,
+  )
+
+  const hashDirect = new Keccak(256)
+  hashDirect.update(Buffer.from(signDocDirect.serializeBinary()))
+  const toSignDirect = hashDirect.digest('binary')
+
+  return {
+    legacyAmino: {
+      body,
+      authInfo: authInfoAmino,
+      signBytes: toSignAmino.toString('base64'),
+    },
+    signDirect: {
+      body,
+      authInfo: authInfoDirect,
+      signBytes: toSignDirect.toString('base64'),
+    },
+  }
 }

--- a/packages/proto/src/transaction/transaction.ts
+++ b/packages/proto/src/transaction/transaction.ts
@@ -215,9 +215,7 @@ export function createTransaction(
 /**
  * Returns a transaction object with the body, authInfo and signBytes for both Amino and SignDirect
  * @param body - The body of the transaction. Must be a valid tx.cosmos.tx.v1beta1.TxBody
- * @param fee - The fee amount
- * @param denom - The fee denomination
- * @param gasLimit - The gas limit
+ * @param fee - The fee of the transaction. Must be a valid tx.cosmos.tx.v1beta1.Fee
  * @param pubKey - The public key of the sender
  * @param sequence - The sequence number of the sender
  * @param accountNumber - The account number of the sender
@@ -226,19 +224,15 @@ export function createTransaction(
  * @returns An object with the legacyAmino and signDirect properties
  */
 export function createTransactionWithBody(
-  body: any,
-  fee: string,
-  denom: string,
-  gasLimit: number,
+  body: tx.cosmos.tx.v1beta1.TxBody,
+  fee: tx.cosmos.tx.v1beta1.Fee,
   pubKey: string,
   sequence: number,
   accountNumber: number,
   chainId: string,
   algo: string = ETH_SECP256K1,
 ) {
-  const feeMessage = createFee(fee, denom, gasLimit)
   const pubKeyDecoded = Buffer.from(pubKey, 'base64')
-
   // AMINO
   const signInfoAmino = createSignerInfo(
     new Uint8Array(pubKeyDecoded),
@@ -247,7 +241,7 @@ export function createTransactionWithBody(
     algo,
   )
 
-  const authInfoAmino = createAuthInfo(signInfoAmino, feeMessage)
+  const authInfoAmino = createAuthInfo(signInfoAmino, fee)
 
   const signDocAmino = createSigDoc(
     body.serializeBinary(),
@@ -268,7 +262,7 @@ export function createTransactionWithBody(
     algo,
   )
 
-  const authInfoDirect = createAuthInfo(signInfoDirect, feeMessage)
+  const authInfoDirect = createAuthInfo(signInfoDirect, fee)
 
   const signDocDirect = createSigDoc(
     body.serializeBinary(),

--- a/packages/realiojs/package.json
+++ b/packages/realiojs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@realiotech/realiojs",
   "description": "JS and TS libs for Realio Network",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -20,9 +20,9 @@
   },
   "dependencies": {
     "@realiotech/address-generator": "~1.0.1",
-    "@realiotech/proto": "~2.6.0",
+    "@realiotech/proto": "~2.7.0",
     "@realiotech/provider": "~2.0.1",
-    "@realiotech/transactions": "~2.6.0",
+    "@realiotech/transactions": "~2.7.0",
     "@types/node": "^17.0.21",
     "shx": "^0.3.4"
   },

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@realiotech/transactions",
   "description": "Transactions generator for RealioNetwork",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -19,7 +19,7 @@
     "coverage": "jest --coverage"
   },
   "dependencies": {
-    "@realiotech/proto": "^2.6.0",
+    "@realiotech/proto": "^2.7.0",
     "@types/node": "^17.0.21",
     "link-module-alias": "^1.2.0",
     "shx": "^0.3.4"

--- a/packages/transactions/src/messages/msgSend.ts
+++ b/packages/transactions/src/messages/msgSend.ts
@@ -46,6 +46,15 @@ export function createTxMessageSend(
   }
 }
 
+/**
+ * Created a msg send body and fee that can be passed into a transaction builder.
+ * The returned body is of type tx.cosmos.tx.v1beta1.TxBody
+ * The returned fee is of type tx.cosmos.tx.v1beta1.Fee
+ * @param senderAddress the sender's address
+ * @param memo the memo
+ * @param params MessageSendParams
+ * @param fee Fee
+ */
 export function createMsgSendBody(
   senderAddress: string,
   memo: string,
@@ -66,6 +75,7 @@ export function createMsgSendBody(
 
 /**
  * Creates a send transaction using a prebuilt body and fee proto msg
+ * The returned object contains signDirect and legacyAmino objects
  * @param body expected to be tx.cosmos.tx.v1beta1.TxBody, temporarily set to any
  * @param chain Chain
  * @param sender Sender

--- a/packages/transactions/src/messages/msgSend.ts
+++ b/packages/transactions/src/messages/msgSend.ts
@@ -1,6 +1,8 @@
 import {
   createMsgSend as protoMsgSend,
   createTransaction,
+  createBodyWithMultipleMessages,
+  createTransactionWithBody,
 } from '@realiotech/proto'
 
 import { Chain, Fee, Sender } from './common'
@@ -28,6 +30,47 @@ export function createTxMessageSend(
   const tx = createTransaction(
     msgSend,
     memo,
+    fee.amount,
+    fee.denom,
+    parseInt(fee.gas, 10),
+    sender.pubkey,
+    sender.sequence,
+    sender.accountNumber,
+    chain.cosmosChainId,
+  )
+
+  return {
+    signDirect: tx.signDirect,
+    legacyAmino: tx.legacyAmino,
+  }
+}
+
+export function createMsgSendBody(
+  sender: Sender,
+  memo: string,
+  params: MessageSendParams,
+) {
+  // Cosmos
+  const msgSend = protoMsgSend(
+    sender.accountAddress,
+    params.destinationAddress,
+    params.amount,
+    params.denom,
+  )
+  const body = createBodyWithMultipleMessages([msgSend], memo)
+
+  return { body }
+}
+
+export function createSendTx(
+  body: any,
+  chain: Chain,
+  sender: Sender,
+  fee: Fee,
+) {
+  // Cosmos
+  const tx = createTransactionWithBody(
+    body,
     fee.amount,
     fee.denom,
     parseInt(fee.gas, 10),

--- a/packages/transactions/src/messages/msgSend.ts
+++ b/packages/transactions/src/messages/msgSend.ts
@@ -3,6 +3,7 @@ import {
   createTransaction,
   createBodyWithMultipleMessages,
   createTransactionWithBody,
+  createFee,
 } from '@realiotech/proto'
 
 import { Chain, Fee, Sender } from './common'
@@ -46,34 +47,40 @@ export function createTxMessageSend(
 }
 
 export function createMsgSendBody(
-  sender: Sender,
+  senderAddress: string,
   memo: string,
   params: MessageSendParams,
+  fee: Fee,
 ) {
   // Cosmos
   const msgSend = protoMsgSend(
-    sender.accountAddress,
+    senderAddress,
     params.destinationAddress,
     params.amount,
     params.denom,
   )
   const body = createBodyWithMultipleMessages([msgSend], memo)
-
-  return { body }
+  const feeMessage = createFee(fee.amount, fee.denom, parseInt(fee.gas, 10))
+  return { body, feeMessage }
 }
 
+/**
+ * Creates a send transaction using a prebuilt body and fee proto msg
+ * @param body expected to be tx.cosmos.tx.v1beta1.TxBody, temporarily set to any
+ * @param chain Chain
+ * @param sender Sender
+ * @param fee expected to be tx.cosmos.tx.v1beta1.Fee, temporarily set to any
+ */
 export function createSendTx(
   body: any,
   chain: Chain,
   sender: Sender,
-  fee: Fee,
+  fee: any,
 ) {
   // Cosmos
   const tx = createTransactionWithBody(
     body,
-    fee.amount,
-    fee.denom,
-    parseInt(fee.gas, 10),
+    fee,
     sender.pubkey,
     sender.sequence,
     sender.accountNumber,


### PR DESCRIPTION
Separate the txn creation process, providing functions for clients to create a msg and fee body first, and later the actual txn message that cosmos expects. 