### PR TITLE
chore: gate yarn installs by 3-day minimum release age

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,1 +1,3 @@
 npmMinimalAgeGate: 4320
+
+npmRegistryServer: "https://registry.npmjs.org"

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+npmMinimalAgeGate: 4320

--- a/package.json
+++ b/package.json
@@ -52,5 +52,6 @@
     "ts-node-dev": "^1.1.8",
     "tsconfig-paths": "^3.11.0",
     "typescript": "^4.7.3"
-  }
+  },
+  "packageManager": "yarn@4.15.0+sha512.faf6b99be7e1e8a88a46b785b2842b0e17f2ba93f16b39764ddadd48407a0a2602d2f4bd7d6a7e58d308215d29d6f9cfeb7919709b020e57324f60a353e18f94"
 }


### PR DESCRIPTION
## Summary
- Adds `npmMinimalAgeGate: 4320` (3 days, in minutes) to `.yarnrc.yml` as a supply-chain defense — yarn will refuse to install package versions younger than 3 days, giving the community time to spot and yank malicious releases
- Pins yarn to 4.15.0 via the `packageManager` field (was previously unset); `npmMinimalAgeGate` requires Yarn Berry ≥ 4.10

## Note for reviewer
This repo currently contains **both** `yarn.lock` and `package-lock.json`. Only yarn is configured here; the stray `package-lock.json` should be deleted in a separate change once a maintainer confirms yarn is the chosen tool.

## Test plan
- [ ] `corepack prepare yarn@4.15.0 --activate`
- [ ] `yarn install --immutable` — confirm lockfile still resolves cleanly under 4.15
- [ ] `yarn build` succeeds (lerna monorepo build)
- [ ] `yarn test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)